### PR TITLE
Nested quotation marks are not escaped

### DIFF
--- a/lib/src/command/download_command.dart
+++ b/lib/src/command/download_command.dart
@@ -10,7 +10,6 @@ import 'package:flutter_lokalise/src/client/lokalise_client.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
-import 'package:string_unescape/string_unescape.dart' show unescape;
 
 import 'arg_results_extension.dart';
 import 'flutter_lokalise_command.dart';
@@ -84,7 +83,7 @@ class DownloadCommand extends FlutterLokaliseCommand<Null> {
       );
       File("$output/intl_$locale.arb")
         ..createSync(recursive: true)
-        ..writeAsStringSync(unescape(JsonEncoder.withIndent("  ").convert(arbMap)));
+        ..writeAsStringSync(JsonEncoder.withIndent("  ").convert(arbMap));
     });
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -470,13 +470,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
-  string_unescape:
-    dependency: "direct main"
-    description:
-      name: string_unescape
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   meta: ">=1.1.0 <2.0.0"
   path: ">=1.5.0 <2.0.0"
   quiver: ">=2.0.0 <3.0.0"
-  string_unescape: ">=1.0.0 <2.0.0"
   yaml: ">=2.0.0 <3.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
Resolves #9.

Keys were unnecessarily unescaped which led invalid arb files. We removed the unescape locally and ran it against around Lokalise server and it worked like a charm. However, the tests were failing and we think the assertion wasn't testing correctly. 

This PR fixes it and the associated test.

Group effort with @vishna.