### PR TITLE
Set default missing key to base lang

### DIFF
--- a/lib/src/client/files_download_request_body.dart
+++ b/lib/src/client/files_download_request_body.dart
@@ -16,6 +16,7 @@ class FilesDownloadRequestBody with _$FilesDownloadRequestBody {
     @Default("icu")
         String? placeholderFormat,
     @JsonKey(name: "include_tags") Iterable<String>? includeTags,
+    @JsonKey(name: "export_empty_as") @Default("base") String? exportEmptyAs,
     @JsonKey(name: "include_comments") @Default(true) bool? includeComments,
     @JsonKey(name: "include_description")
     @Default(true)

--- a/lib/src/client/files_download_request_body.freezed.dart
+++ b/lib/src/client/files_download_request_body.freezed.dart
@@ -33,6 +33,8 @@ class _$FilesDownloadRequestBodyTearOff {
           String? placeholderFormat = "icu",
       @JsonKey(name: "include_tags")
           Iterable<String>? includeTags,
+      @JsonKey(name: "export_empty_as")
+          String? exportEmptyAs = "base",
       @JsonKey(name: "include_comments")
           bool? includeComments = true,
       @JsonKey(name: "include_description")
@@ -46,6 +48,7 @@ class _$FilesDownloadRequestBodyTearOff {
       pluralFormat: pluralFormat,
       placeholderFormat: placeholderFormat,
       includeTags: includeTags,
+      exportEmptyAs: exportEmptyAs,
       includeComments: includeComments,
       includeDescription: includeDescription,
       jsonUnescapedSlashes: jsonUnescapedSlashes,
@@ -73,6 +76,8 @@ mixin _$FilesDownloadRequestBody {
   String? get placeholderFormat => throw _privateConstructorUsedError;
   @JsonKey(name: "include_tags")
   Iterable<String>? get includeTags => throw _privateConstructorUsedError;
+  @JsonKey(name: "export_empty_as")
+  String? get exportEmptyAs => throw _privateConstructorUsedError;
   @JsonKey(name: "include_comments")
   bool? get includeComments => throw _privateConstructorUsedError;
   @JsonKey(name: "include_description")
@@ -98,6 +103,7 @@ abstract class $FilesDownloadRequestBodyCopyWith<$Res> {
       @JsonKey(name: "plural_format") String? pluralFormat,
       @JsonKey(name: "placeholder_format") String? placeholderFormat,
       @JsonKey(name: "include_tags") Iterable<String>? includeTags,
+      @JsonKey(name: "export_empty_as") String? exportEmptyAs,
       @JsonKey(name: "include_comments") bool? includeComments,
       @JsonKey(name: "include_description") bool? includeDescription,
       @JsonKey(name: "json_unescaped_slashes") bool? jsonUnescapedSlashes});
@@ -120,6 +126,7 @@ class _$FilesDownloadRequestBodyCopyWithImpl<$Res>
     Object? pluralFormat = freezed,
     Object? placeholderFormat = freezed,
     Object? includeTags = freezed,
+    Object? exportEmptyAs = freezed,
     Object? includeComments = freezed,
     Object? includeDescription = freezed,
     Object? jsonUnescapedSlashes = freezed,
@@ -149,6 +156,10 @@ class _$FilesDownloadRequestBodyCopyWithImpl<$Res>
           ? _value.includeTags
           : includeTags // ignore: cast_nullable_to_non_nullable
               as Iterable<String>?,
+      exportEmptyAs: exportEmptyAs == freezed
+          ? _value.exportEmptyAs
+          : exportEmptyAs // ignore: cast_nullable_to_non_nullable
+              as String?,
       includeComments: includeComments == freezed
           ? _value.includeComments
           : includeComments // ignore: cast_nullable_to_non_nullable
@@ -179,6 +190,7 @@ abstract class _$FilesDownloadRequestBodyCopyWith<$Res>
       @JsonKey(name: "plural_format") String? pluralFormat,
       @JsonKey(name: "placeholder_format") String? placeholderFormat,
       @JsonKey(name: "include_tags") Iterable<String>? includeTags,
+      @JsonKey(name: "export_empty_as") String? exportEmptyAs,
       @JsonKey(name: "include_comments") bool? includeComments,
       @JsonKey(name: "include_description") bool? includeDescription,
       @JsonKey(name: "json_unescaped_slashes") bool? jsonUnescapedSlashes});
@@ -204,6 +216,7 @@ class __$FilesDownloadRequestBodyCopyWithImpl<$Res>
     Object? pluralFormat = freezed,
     Object? placeholderFormat = freezed,
     Object? includeTags = freezed,
+    Object? exportEmptyAs = freezed,
     Object? includeComments = freezed,
     Object? includeDescription = freezed,
     Object? jsonUnescapedSlashes = freezed,
@@ -233,6 +246,10 @@ class __$FilesDownloadRequestBodyCopyWithImpl<$Res>
           ? _value.includeTags
           : includeTags // ignore: cast_nullable_to_non_nullable
               as Iterable<String>?,
+      exportEmptyAs: exportEmptyAs == freezed
+          ? _value.exportEmptyAs
+          : exportEmptyAs // ignore: cast_nullable_to_non_nullable
+              as String?,
       includeComments: includeComments == freezed
           ? _value.includeComments
           : includeComments // ignore: cast_nullable_to_non_nullable
@@ -264,6 +281,8 @@ class _$_FilesDownloadRequestBody implements _FilesDownloadRequestBody {
           this.placeholderFormat = "icu",
       @JsonKey(name: "include_tags")
           this.includeTags,
+      @JsonKey(name: "export_empty_as")
+          this.exportEmptyAs = "base",
       @JsonKey(name: "include_comments")
           this.includeComments = true,
       @JsonKey(name: "include_description")
@@ -292,6 +311,9 @@ class _$_FilesDownloadRequestBody implements _FilesDownloadRequestBody {
   @JsonKey(name: "include_tags")
   final Iterable<String>? includeTags;
   @override
+  @JsonKey(name: "export_empty_as")
+  final String? exportEmptyAs;
+  @override
   @JsonKey(name: "include_comments")
   final bool? includeComments;
   @override
@@ -303,7 +325,7 @@ class _$_FilesDownloadRequestBody implements _FilesDownloadRequestBody {
 
   @override
   String toString() {
-    return 'FilesDownloadRequestBody(format: $format, originalFilenames: $originalFilenames, allPlatforms: $allPlatforms, pluralFormat: $pluralFormat, placeholderFormat: $placeholderFormat, includeTags: $includeTags, includeComments: $includeComments, includeDescription: $includeDescription, jsonUnescapedSlashes: $jsonUnescapedSlashes)';
+    return 'FilesDownloadRequestBody(format: $format, originalFilenames: $originalFilenames, allPlatforms: $allPlatforms, pluralFormat: $pluralFormat, placeholderFormat: $placeholderFormat, includeTags: $includeTags, exportEmptyAs: $exportEmptyAs, includeComments: $includeComments, includeDescription: $includeDescription, jsonUnescapedSlashes: $jsonUnescapedSlashes)';
   }
 
   @override
@@ -327,6 +349,9 @@ class _$_FilesDownloadRequestBody implements _FilesDownloadRequestBody {
             (identical(other.includeTags, includeTags) ||
                 const DeepCollectionEquality()
                     .equals(other.includeTags, includeTags)) &&
+            (identical(other.exportEmptyAs, exportEmptyAs) ||
+                const DeepCollectionEquality()
+                    .equals(other.exportEmptyAs, exportEmptyAs)) &&
             (identical(other.includeComments, includeComments) ||
                 const DeepCollectionEquality()
                     .equals(other.includeComments, includeComments)) &&
@@ -347,6 +372,7 @@ class _$_FilesDownloadRequestBody implements _FilesDownloadRequestBody {
       const DeepCollectionEquality().hash(pluralFormat) ^
       const DeepCollectionEquality().hash(placeholderFormat) ^
       const DeepCollectionEquality().hash(includeTags) ^
+      const DeepCollectionEquality().hash(exportEmptyAs) ^
       const DeepCollectionEquality().hash(includeComments) ^
       const DeepCollectionEquality().hash(includeDescription) ^
       const DeepCollectionEquality().hash(jsonUnescapedSlashes);
@@ -376,6 +402,8 @@ abstract class _FilesDownloadRequestBody implements FilesDownloadRequestBody {
           String? placeholderFormat,
       @JsonKey(name: "include_tags")
           Iterable<String>? includeTags,
+      @JsonKey(name: "export_empty_as")
+          String? exportEmptyAs,
       @JsonKey(name: "include_comments")
           bool? includeComments,
       @JsonKey(name: "include_description")
@@ -403,6 +431,9 @@ abstract class _FilesDownloadRequestBody implements FilesDownloadRequestBody {
   @override
   @JsonKey(name: "include_tags")
   Iterable<String>? get includeTags => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(name: "export_empty_as")
+  String? get exportEmptyAs => throw _privateConstructorUsedError;
   @override
   @JsonKey(name: "include_comments")
   bool? get includeComments => throw _privateConstructorUsedError;

--- a/lib/src/client/files_download_request_body.g.dart
+++ b/lib/src/client/files_download_request_body.g.dart
@@ -16,6 +16,7 @@ _$_FilesDownloadRequestBody _$_$_FilesDownloadRequestBodyFromJson(
     placeholderFormat: json['placeholder_format'] as String?,
     includeTags:
         (json['include_tags'] as List<dynamic>?)?.map((e) => e as String),
+    exportEmptyAs: json['export_empty_as'] as String?,
     includeComments: json['include_comments'] as bool?,
     includeDescription: json['include_description'] as bool?,
     jsonUnescapedSlashes: json['json_unescaped_slashes'] as bool?,
@@ -31,6 +32,7 @@ Map<String, dynamic> _$_$_FilesDownloadRequestBodyToJson(
       'plural_format': instance.pluralFormat,
       'placeholder_format': instance.placeholderFormat,
       'include_tags': instance.includeTags?.toList(),
+      'export_empty_as': instance.exportEmptyAs,
       'include_comments': instance.includeComments,
       'include_description': instance.includeDescription,
       'json_unescaped_slashes': instance.jsonUnescapedSlashes,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "21.0.0"
+    version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.7.2"
   archive:
     dependency: "direct main"
     description:
@@ -28,14 +28,14 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   build_config:
     dependency: transitive
     description:
@@ -70,42 +70,42 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.6"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.6"
+    version: "8.1.1"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.3"
   code_builder:
     dependency: transitive
     description:
@@ -140,14 +140,14 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
@@ -238,7 +238,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
+    version: "4.1.3"
   logging:
     dependency: "direct main"
     description:
@@ -280,7 +280,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -301,14 +301,14 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.8"
+    version: "5.0.10"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
@@ -329,7 +329,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
@@ -371,7 +371,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -385,7 +385,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -399,7 +399,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -462,21 +462,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.4"
+    version: "1.17.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.29"
   timing:
     dependency: transitive
     description:
@@ -497,7 +497,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "7.1.0"
   watcher:
     dependency: transitive
     description:

--- a/test/client/lokalise_client_integration_test.dart
+++ b/test/client/lokalise_client_integration_test.dart
@@ -60,6 +60,7 @@ void main() {
             "include_comments": true,
             "include_description": true,
             "include_tags": ["tag"],
+            "export_empty_as": "base",
             "json_unescaped_slashes": true,
           }));
       final body = response.typedBody;


### PR DESCRIPTION
Add export_empty_as parameter and defaults it to base. 
This will download the localization files and if a key is missing will fall back to its base language. 